### PR TITLE
chore: link README.md to yerpc folder for crates.io

### DIFF
--- a/yerpc/README.md
+++ b/yerpc/README.md
@@ -1,0 +1,1 @@
+../README.md


### PR DESCRIPTION
fixes #39. It's just a symlink to the main README.md. IIRC `cargo publish` supports this (but didn't test myself).