### PR TITLE
fix memory leak in ts client.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 All notable changes to this project will be documented in this file.
 
+## Unreleased
+
+- ts client: fix memory leak
+
 ## 0.5.3 - 2023-12-02
 
 - Update axum

--- a/typescript/client.ts
+++ b/typescript/client.ts
@@ -40,6 +40,7 @@ export abstract class BaseTransport<T = {}>
     if (!handler) return; // TODO: Handle error.
     if (response.error) handler.reject(response.error);
     else handler.resolve(response.result);
+    this._requests.delete(response.id)
   }
 
   notification(method: string, params?: Params): void {


### PR DESCRIPTION
Old Promises including their return values were not garbage collected, because they were not removed from the `_requests` Map.

fixes #60
