### PR TITLE
Update Axum & other dependencies

### DIFF
--- a/examples/axum/Cargo.toml
+++ b/examples/axum/Cargo.toml
@@ -11,18 +11,18 @@ name = "yerpc-axum"
 path = "src/webserver.rs"
 
 [dependencies]
-anyhow = "1.0.57"
-serde = "1.0.136"
-serde_json = "1.0.79"
-axum = { version = "0.7.1", features = ["ws"] }
-futures = "0.3.21"
-log = "0.4.16"
-async-trait = "0.1.53"
-typescript-type-def = { version = "0.5.3", features = ["json_value"] }
-async-broadcast = "0.4.0"
-tokio = { version = "1.19.2", features = ["full"] }
-tower-http = { version = "0.5.0", features = ["trace"] }
-tracing = "0.1.35"
-tracing-subscriber = "0.3.11"
-schemars = "0.8.11"
+anyhow = "1.0.95"
+serde = "1.0.217"
+serde_json = "1.0.138"
+axum = { version = "0.8.1", features = ["ws"] }
+futures = "0.3.31"
+log = "0.4.25"
+async-trait = "0.1.86"
+typescript-type-def = { version = "0.5.13", features = ["json_value"] }
+async-broadcast = "0.4.1"
+tokio = { version = "1.43.0", features = ["full"] }
+tower-http = { version = "0.5.2", features = ["trace"] }
+tracing = "0.1.41"
+tracing-subscriber = "0.3.19"
+schemars = "0.8.21"
 yerpc = { path  = "../../yerpc", features = ["anyhow", "support-axum"]}

--- a/examples/tide/Cargo.toml
+++ b/examples/tide/Cargo.toml
@@ -13,14 +13,14 @@ path = "src/webserver.rs"
 [dependencies]
 tide = "0.16.0"
 tide-websockets = "0.4.0"
-anyhow = "1.0.57"
-serde = "1.0.136"
-serde_json = "1.0.79"
+anyhow = "1.0.95"
+serde = "1.0.217"
+serde_json = "1.0.138"
 async-std = { version = "1.11.0", features = ["attributes"] }
-futures = "0.3.21"
+futures = "0.3.31"
 env_logger = "0.9.0"
-log = "0.4.16"
+log = "0.4.25"
 async-trait = "0.1.53"
-typescript-type-def = { version = "0.5.3", features = ["json_value"] }
+typescript-type-def = { version = "0.5.13", features = ["json_value"] }
 async-broadcast = "0.4.0"
 yerpc = { path  = "../../yerpc", features = ["anyhow"]}

--- a/yerpc-derive/src/lib.rs
+++ b/yerpc-derive/src/lib.rs
@@ -25,20 +25,20 @@ pub(crate) mod util;
 ///
 /// ### Root Attribute Arguments:
 /// - `all_positional: bool` Positional mode means that the parameters of the RPC call are expected to be a JSON array,
-/// which will be parsed as a tuple of this function's arguments.
+///   which will be parsed as a tuple of this function's arguments.
 /// - `ts_outdir: Option<String>` Set the path where typescript definitions are written to (relative to the crate root).
-/// If not set, no typescript definitions will be written.
+///   If not set, no typescript definitions will be written.
 /// - `openrpc_outdir: Option<String>` Set the path where openrpc specification file will be written to (relative to the crate root).
-/// If not set, no openrpc definition file will be written.
+///   If not set, no openrpc definition file will be written.
 ///
 /// Note that you need to specify atleast one type definition output: `ts_outdir`, `openrpc_outdir` or both.
 ///
 /// ### Method Attribute Arguments:
 /// - `name: Option<String>` Set the name of the RPC method. Defaults to the function name.
 /// - `notification: bool` Make this a notification method. Notifications are received like method calls but cannot
-/// return anything.
+///   return anything.
 /// - `positional: bool` Positional mode means that the parameters of the RPC call are expected to be a JSON array,
-/// which will be parsed as a tuple of this function's arguments.
+///   which will be parsed as a tuple of this function's arguments.
 #[proc_macro_attribute]
 pub fn rpc(attr: TokenStream, tokens: TokenStream) -> TokenStream {
     let item = parse_macro_input!(tokens as Item);

--- a/yerpc/Cargo.toml
+++ b/yerpc/Cargo.toml
@@ -17,25 +17,25 @@ name = "generate-base-types"
 
 [dependencies]
 yerpc_derive = { path  = "../yerpc-derive", version = "0.6" }
-async-trait = "0.1.53"
-serde = { version = "1.0.136", features = ["derive"] }
-serde_json = "1.0.79"
-log = "0.4.16"
-futures = "0.3.21"
-futures-util = "0.3.21"
-async-channel = "1.6.1"
+async-trait = "0.1.86"
+serde = { version = "1.0.217", features = ["derive"] }
+serde_json = "1.0.138"
+log = "0.4.25"
+futures = "0.3.31"
+futures-util = "0.3.31"
+async-channel = "1.9.0"
 async-mutex = "1.4.0"
 
 # type generating dependencies
-typescript-type-def = { version = "0.5.3", features = ["json_value"] }
-schemars = { version = "0.8.11", optional = true }
+typescript-type-def = { version = "0.5.13", features = ["json_value"] }
+schemars = { version = "0.8.21", optional = true }
 
 # optional dependencies
-anyhow = { version = "1.0.57", optional = true }
-axum = { version = "0.7.1", features = ["ws"], optional = true }
-tokio-tungstenite = { version = "0.20", optional = true }
-tokio = { version = "1.19.2", features = ["rt", "macros"], optional = true }
-tracing = { version = "0.1.35", optional = true }
+anyhow = { version = "1.0.95", optional = true }
+axum = { version = "0.8.1", features = ["ws"], optional = true }
+tokio-tungstenite = { version = "0.26.1", optional = true }
+tokio = { version = "1.43.0", features = ["rt", "macros"], optional = true }
+tracing = { version = "0.1.41", optional = true }
 
 [features]
 anyhow_expose = ["anyhow"]
@@ -44,8 +44,8 @@ support-tungstenite = ["tokio", "tokio-tungstenite", "anyhow"]
 openrpc = ["schemars", "yerpc_derive/openrpc"]
 
 [dev-dependencies]
-anyhow = "1.0.57"
-axum = { version = "0.7.1", features = ["ws"] }
-tokio-tungstenite = { version = "0.20" }
-tokio = { version = "1.19.2", features = ["rt", "macros"] }
-url = "2.2.2"
+anyhow = "1.0.95"
+axum = { version = "0.8.1", features = ["ws"] }
+tokio-tungstenite = { version = "0.26.1" }
+tokio = { version = "1.43.0", features = ["rt", "macros"] }
+url = "2.5.4"

--- a/yerpc/src/integrations/axum.rs
+++ b/yerpc/src/integrations/axum.rs
@@ -29,7 +29,7 @@ pub async fn handle_rpc<T: RpcServer>(
         while let Some(message) = out_rx.next().await {
             let message = serde_json::to_string(&message)?;
             tracing::trace!("RPC send {}", message);
-            sender.send(Message::Text(message)).await?;
+            sender.send(Message::Text(message.into())).await?;
         }
         Ok(())
     });

--- a/yerpc/src/integrations/tungstenite.rs
+++ b/yerpc/src/integrations/tungstenite.rs
@@ -37,7 +37,7 @@ where
         tokio::select! {
             message = out_rx.next() => {
                     let message = serde_json::to_string(&message)?;
-                    stream.send(Message::Text(message)).await?;
+                    stream.send(Message::Text(message.into())).await?;
             }
             message = stream.next() => {
                 match message {

--- a/yerpc/src/version.rs
+++ b/yerpc/src/version.rs
@@ -49,7 +49,7 @@ impl<'a> Deserialize<'a> for Version {
 
 struct VersionVisitor;
 
-impl<'a> Visitor<'a> for VersionVisitor {
+impl Visitor<'_> for VersionVisitor {
     type Value = Version;
 
     fn expecting(&self, formatter: &mut fmt::Formatter) -> fmt::Result {

--- a/yerpc/tests/axum.rs
+++ b/yerpc/tests/axum.rs
@@ -48,7 +48,7 @@ mod tests {
         let tcp = TcpStream::connect("127.0.0.1:12345")
             .await
             .expect("Failed to connect");
-        let url = url::Url::parse("ws://localhost:12345/rpc").unwrap();
+        let url = "ws://localhost:12345/rpc";
         let (mut stream, response) = client_async(url, tcp)
             .await
             .expect("Client failed to connect");


### PR DESCRIPTION
Primary goal of this PR is to update to the latest version of Axum, 8.1.

While at it, I took the liberty to update a number of other dependencies as well.

These changes have been tested against a local project that uses Yerpc together with Axum.